### PR TITLE
Preserve SMTP envelope recipients when relaying

### DIFF
--- a/installer/SmtpRelayInstaller.iss
+++ b/installer/SmtpRelayInstaller.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=SMTP Relay
-AppVersion=1.5
+AppVersion=1.5.1
 DefaultDirName={pf64}\SMTP Relay
 ArchitecturesInstallIn64BitMode=x64
 DefaultGroupName=SMTP Relay

--- a/src/SmtpRelay.GUI/SmtpRelay.GUI.csproj
+++ b/src/SmtpRelay.GUI/SmtpRelay.GUI.csproj
@@ -7,8 +7,8 @@
     <UseWindowsForms>true</UseWindowsForms>
 
     <!-- version string shown in GUI (Program.AppVersion) -->
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
-    <FileVersion>1.5.0.0</FileVersion>
+    <AssemblyVersion>1.5.1.0</AssemblyVersion>
+    <FileVersion>1.5.1.0</FileVersion>
 
     <!-- set icon for EXE / taskbar -->
     <ApplicationIcon>smtp.ico</ApplicationIcon>

--- a/src/SmtpRelay/MessageRelayStore.cs
+++ b/src/SmtpRelay/MessageRelayStore.cs
@@ -106,11 +106,11 @@ namespace SmtpRelay
             if (!string.IsNullOrWhiteSpace(_cfg.Username))
                 await client.AuthenticateAsync(_cfg.Username, _cfg.Password ?? string.Empty, cancellationToken);
 
-            var sender = new MailboxAddress(string.Empty, transaction.From.Address);
+            var sender = new MailboxAddress(string.Empty, $"{transaction.From.User}@{transaction.From.Host}");
             var recipients = new List<MailboxAddress>();
 
             foreach (var recipient in transaction.To)
-                recipients.Add(new MailboxAddress(string.Empty, recipient.Address));
+                recipients.Add(new MailboxAddress(string.Empty, $"{recipient.User}@{recipient.Host}"));
 
             await client.SendAsync(message, sender, recipients, cancellationToken);
             await client.DisconnectAsync(true, cancellationToken);

--- a/src/SmtpRelay/MessageRelayStore.cs
+++ b/src/SmtpRelay/MessageRelayStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Reflection;
@@ -75,12 +76,12 @@ namespace SmtpRelay
                     var proto = new RedactingSmtpProtocolLogger(protoPath, append: true);
 
                     using var client = new SmtpClient(proto) { Timeout = 15000 };
-                    await SendWithClientAsync(client, message, socketOptions, cancellationToken);
+                    await SendWithClientAsync(client, message, transaction, socketOptions, cancellationToken);
                 }
                 else
                 {
                     using var client = new SmtpClient { Timeout = 15000 };
-                    await SendWithClientAsync(client, message, socketOptions, cancellationToken);
+                    await SendWithClientAsync(client, message, transaction, socketOptions, cancellationToken);
                 }
 
                 _log.LogInformation("Relayed mail from {IP}", clientIp);
@@ -96,6 +97,7 @@ namespace SmtpRelay
         private async Task SendWithClientAsync(
             SmtpClient client,
             MimeMessage message,
+            IMessageTransaction transaction,
             SecureSocketOptions socketOptions,
             CancellationToken cancellationToken)
         {
@@ -104,7 +106,13 @@ namespace SmtpRelay
             if (!string.IsNullOrWhiteSpace(_cfg.Username))
                 await client.AuthenticateAsync(_cfg.Username, _cfg.Password ?? string.Empty, cancellationToken);
 
-            await client.SendAsync(message, cancellationToken);
+            var sender = MailboxAddress.Parse(transaction.From.ToString());
+            var recipients = new List<MailboxAddress>();
+
+            foreach (var recipient in transaction.To)
+                recipients.Add(MailboxAddress.Parse(recipient.ToString()));
+
+            await client.SendAsync(message, sender, recipients, cancellationToken);
             await client.DisconnectAsync(true, cancellationToken);
         }
 

--- a/src/SmtpRelay/MessageRelayStore.cs
+++ b/src/SmtpRelay/MessageRelayStore.cs
@@ -106,11 +106,11 @@ namespace SmtpRelay
             if (!string.IsNullOrWhiteSpace(_cfg.Username))
                 await client.AuthenticateAsync(_cfg.Username, _cfg.Password ?? string.Empty, cancellationToken);
 
-            var sender = MailboxAddress.Parse(transaction.From.ToString());
+            var sender = new MailboxAddress(string.Empty, transaction.From.Address);
             var recipients = new List<MailboxAddress>();
 
             foreach (var recipient in transaction.To)
-                recipients.Add(MailboxAddress.Parse(recipient.ToString()));
+                recipients.Add(new MailboxAddress(string.Empty, recipient.Address));
 
             await client.SendAsync(message, sender, recipients, cancellationToken);
             await client.DisconnectAsync(true, cancellationToken);

--- a/src/SmtpRelay/SmtpRelay.csproj
+++ b/src/SmtpRelay/SmtpRelay.csproj
@@ -16,8 +16,8 @@
     <Nullable>enable</Nullable>
 
     <!-- version for service exe -->
-    <AssemblyVersion>1.5.0.0</AssemblyVersion>
-    <FileVersion>1.5.0.0</FileVersion>
+    <AssemblyVersion>1.5.1.0</AssemblyVersion>
+    <FileVersion>1.5.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes relay dropping BCC recipients.

The relay was reconstructing recipients from MIME headers when sending upstream. BCC recipients are often not present in message headers, only in the SMTP envelope (RCPT TO).

This change forwards the envelope sender and recipient list from IMessageTransaction so all accepted recipients (To, Cc, Bcc) are relayed correctly.